### PR TITLE
[refactor]: DOM 셀렉터 상수화 및 전역 상태 재배치

### DIFF
--- a/subtitle/manifest.json
+++ b/subtitle/manifest.json
@@ -2,7 +2,7 @@
 {
   "manifest_version": 3,
   "name": "Subtitle Extension-final", 
-  "version": "5.3",
+  "version": "5.7",
   "description": "Provides customed Korean subtitles for particular videos.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": [


### PR DESCRIPTION
주요 변경
- SELECTORS 상수 객체 도입: Udemy DOM 셀렉터 중앙 관리
  * TRANSCRIPT_TOGGLE, TRANSCRIPT_CONTAINER, TRANSCRIPT_TEXT
  * LECTURE_TITLE
  * SUBTITLE_CONTAINER, SUBTITLE_TEXT
  * ENGLISH_SUBTITLE, KOREAN_SUBTITLE
  * VIDEO
- STATE 객체를 파일 최상단(26번 라인)으로 이동
  * 기존 373번 라인에서 상단으로 재배치
  * 파일 진입 시 전역 상태 즉시 파악 가능
- 하드코딩된 querySelector 셀렉터를 SELECTORS 참조로 전면 교체
  * openSidebarAndExtractTranscript(), extractTitle(), extractScript()
  * shadowDomInit(), showLoadingIndicator(), hideLoadingIndicator()
  * getShadowSubtitleElements(), processSubtitleElement(), updateSubtitles()
  * ensureObserver(), primeFirstSubtitle(), setupPrimeOnPlayback()
- manifest.json: 버전 5.6 → 5.7

의도/효과
- Udemy UI 변경 시 SELECTORS 객체 한 곳만 수정하면 전체 반영
- 셀렉터 오타 위험 감소 및 IDE 자동완성 지원
- 파일 최상단에서 전역 상수/상태를 한눈에 확인 가능
- 코드 가독성 및 유지보수성 향상

검증 포인트
- SELECTORS.SUBTITLE_TEXT 등 상수 참조가 정상 동작하는지
- STATE 최상단 배치로 인한 참조 문제가 없는지
- 기존 DOM 탐색 로직이 모두 정상 동작하는지

브레이킹 체인지
- 없음 (순수 리팩토링, 기능 변경 없음)