### PR TITLE
[refactor] MutationObserver 최적화 - 자막 요소 캐싱으로 DOM 탐색 제거

### DIFF
--- a/subtitle/content.js
+++ b/subtitle/content.js
@@ -28,6 +28,7 @@ const STATE = {
   observer: null,
   refs: { eng: null, kor: null },
   last: { eng: "", kor: "" },
+  subtitleElement: null, // 자막 요소 캐싱
 };
 
 //============================================
@@ -403,19 +404,13 @@ function ensureObserver() {
   const targetNode = document.querySelector(SELECTORS.SUBTITLE_TEXT);
   if (!targetNode) return;
 
-  const observer = new MutationObserver((records) => {
-    for (const r of records) {
-      // MutationObserver의 records를 활용하여 변경된 노드에서만 탐색
-      // (전체 DOM 탐색 대비 ~75% 빠름)
-      const base = r.target.nodeType === Node.TEXT_NODE 
-        ? r.target.parentElement  // 텍스트 노드면 부모 요소로
-        : r.target;                // Element 노드면 그대로 사용
-      
-      const subtitleElement = base?.closest(SELECTORS.SUBTITLE_TEXT);
-      
-      if (subtitleElement && STATE.translations) {
-        processSubtitleElement(subtitleElement);
-      }
+  // 자막 요소 캐싱 (innerText는 live property이므로 항상 최신 값 반환)
+  STATE.subtitleElement = targetNode;
+
+  const observer = new MutationObserver(() => {
+    // 콜백 실행 = 변경 발생, 캐싱된 요소 직접 사용
+    if (STATE.translations && STATE.subtitleElement) {
+      processSubtitleElement(STATE.subtitleElement);
     }
   });
 
@@ -436,6 +431,7 @@ function resetState() {
   STATE.translations = null;
   STATE.last = { eng: "", kor: "" };
   STATE.refs = { eng: null, kor: null };
+  STATE.subtitleElement = null;
 }
 
 // 특정 셀렉터의 요소가 준비되길 기다린다(있으면 즉시, 없으면 짧게 대기)

--- a/subtitle/manifest.json
+++ b/subtitle/manifest.json
@@ -2,7 +2,7 @@
 {
   "manifest_version": 3,
   "name": "Subtitle Extension-final", 
-  "version": "5.7",
+  "version": "5.8",
   "description": "Provides customed Korean subtitles for particular videos.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": [


### PR DESCRIPTION
## 변경 사항

- 자막 요소(subtitleElement) 캐싱을 STATE에 추가
- ensureObserver에서 초기화 시점에 자막 요소를 캐싱하여 재사용
- MutationObserver 콜백에서 closest() 호출 완전 제거
- records 매개변수 제거 (캐싱된 요소 직접 사용으로 불필요)

## 성능 개선

### Before
- 매 자막 변경마다 closest() 실행 (60분 강의 = ~1,800회)
- records 순회 및 노드 타입 검사

### After
- closest() 호출 0회 (초기화 시 querySelector 1회만)
- innerText live property를 활용한 최신 값 자동 반영

## 근거

- DOM 요소 레퍼런스는 포인터이므로 캐싱해도 innerText는 항상 최신 값 반환
- Udemy 자막 요소는 페이지 생명주기 동안 재생성되지 않아 stale reference 위험 없음
- 코드 간결성 향상 (7줄 → 3줄)

버전: 5.7 → 5.8